### PR TITLE
Updated struct definition and prototypes

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -1,28 +1,45 @@
 #include "holberton.h"
 
 /**
- * _printf - custom printf function
- * @format: string we need to parse, format and print
- * Return: character count of printed characters
+ * _printf - prints a string depending on format
+ * @format: string contains chars and specifier(s)
+ * Return: number of bytes of format string printed
  */
+
 int _printf(const char *format, ...)
 {
-	int char_count;
 	va_list args;
-
-	print_t spec_list[] = {
-		{"c", print_char},
-		{"s", print_string},
-		{"%", print_percent},
-		{NULL, NULL}
-	};
+	int (*fptr)(va_list);
+	unsigned int index = 0, char_count = 0;
 
 	if (format == NULL)
 		return (-1);
 
 	va_start(args, format);
-	char_count = get_function(format, spec_list, args);
-	va_end(args);
 
+	while (format[index])
+	{
+		for (; format[index] && format[index] != '%'; index++)
+		{
+			_putchar(format[index]);
+			char_count++;
+		}
+		if (!format[index])
+			return (char_count);
+		
+		fptr = get_function(&format[index + 1]);
+		if (fptr != NULL)
+		{
+			char_count += fptr(args);
+			index += 2;
+			continue;
+		}
+
+		if (format[index + 1] == '%')
+			index += 2;
+		else
+			index++;
+	}
+	va_end(args);
 	return (char_count);
 }

--- a/get_function.c
+++ b/get_function.c
@@ -1,48 +1,24 @@
 #include "holberton.h"
 
 /**
- * get_function - finds function that we need
- * @fmt: format string passed
- * @spec_list: list of format structs we are parsing through
- * @args: arguments passed in _printf function call
- * Return: number of arguments called
+ * get_function - compares conversion specifier with first index of struct
+ * @fmt: format specifier
+ * @spec_list: array of structs of print_t type
+ * Return: pointer to valid print function
  */
-int get_function(const char *fmt, print_t spec_list[], va_list args)
+int (*get_function(const char *fmt))(va_list)
 {
-	int i, j, ret_val, numchars;
-
-	numchars = 0;
-
-	for (i = 0; fmt[i] != '\0'; i++)
+print_t spec_list[] = {
+		{"c", print_char},
+		{"s", print_string},
+		{NULL, NULL}
+	};
+	int i;
+	
+	for (i = 0; spec_list[i].sym != NULL; i++)
 	{
-		if (fmt[i] == '%') /* if we come across magic symbol*/
-		{
-			for (j = 0; spec_list[j].sym != NULL; j++)
-			{
-				if (fmt[i + 1] == spec_list[j].sym[0]) /*if match w/ struct sym member*/
-					ret_val = spec_list.fptr(args); /*call the func at index j if match*/
-
-				if (ret_val == -1)
-					return (-1);
-
-				numchars += ret_val;
-				break;
-			}
-			/*case no match, still string:print current char, next char &add to count*/
-			if (spec_list.sym == NULL && fmt[i + 1] == ' ')
-				if (fmt[i + 1] != '\0')
-				{
-					write_char(fmt[i]);
-					write_char(fmt[i + 1]);
-					numchars += 2;
-				}
-				return (-1);
-		}
-		else
-		{
-			write_char(fmt[i]);
-			numchars++;
-		}
+		if (*(spec_list[i].sym) == *fmt)
+			break;
 	}
-	return (numchars);
+	return (spec_list[i].ptr);
 }

--- a/holberton.h
+++ b/holberton.h
@@ -10,20 +10,20 @@
 /**
  * struct specifier_functions - struct to choose function based on specifier
  * @sym: format specifier
- * @fptr: pointer to function to print
+ * @ptr: pointer to function to print
  */
-struct specifier_functions
+
+typedef struct specifier_functions
 {
 	char *sym;
-	int (*fptr)(va_list);
-};
-typedef struct specifier_functions print_t;
+	int (*ptr)(va_list);
+} print_t;
 
 int print_char(va_list c);
 int print_string(va_list s);
-int print_percent(va_list i);
 int print_int(va_list d);
 int print_int(va_list i);
+int print_percent(va_list i);
 int print_binary(va_list b);
 int print_octal(va_list o);
 int print_unsigned(va_list u);
@@ -33,9 +33,8 @@ int print_address(va_list p);
 int print_S(va_list S);
 int print_rev(va_list r);
 int print_rot13(va_list R);
-
 int _printf(const char *format, ...);
-int get_function(char *fmt, print_t spec_list, va_list args);
+int (*get_function(const char *fmt))(va_list);
 int _putchar(char c);
 
 #endif  /* _HOLBERTON_H */


### PR DESCRIPTION
Aside from updating the pointer name (to not be duplicate of function pointer variable declared in update _printf), my understanding is that defining the struct using typedef in this way is more concise.

Whether we use typedef or a structure tag to declare specifier_functions makes little difference. Using typedef results in slightly more concise code bc the _struct_ keyword doesn't have to be used. On the other hand, using a tag and having the struct keyword explicit makes it clear that it is a structure being declared.